### PR TITLE
Use hardlinks for immutable RPMs

### DIFF
--- a/manage/repoclone.yml
+++ b/manage/repoclone.yml
@@ -1,4 +1,4 @@
-# Play to clone already synchronized repos, or to sync two local repos 
+# Play to clone already synchronized repos, or to copy local repos
 # Usage: ansible-playbook -i /path/to/bicycle-inventory ./repoclone.yml --extra-vars "bicycle=bicycle-ip from_repo=rhel-7-server-rpms to_repo=rhel7-180812"
 
 - hosts: all
@@ -11,6 +11,5 @@
       state: directory
       recurse: yes
 
-  - name: Synchronizing repository directory
-    shell: /usr/bin/rsync --delay-updates -F --compress --delete-after --archive /var/www/html/repos/{{ from_repo }}/ /var/www/html/repos/{{ to_repo }}
-    
+  - name: Copy and hardlink repository directory
+    shell: /bin/cp -al /var/www/html/repos/{{ from_repo }}/ /var/www/html/repos/{{ to_repo }}


### PR DESCRIPTION
Using copy with hardlink creation solves data deduplication on the RPM level. RPMs themselves are immutable. So hardlinks are sufficient. For the sake of simplicity and I/O saving a delete-after mechanism is not implemented. The only I/O happening right now is the generation of inodes in the FS inode table. Dramatically speeding up repository cloning.

```
[root@412d1bec7163 centos]# time cp -al extras extras2

real  0m0.021s
user  0m0.001s
sys  0m0.020s
[root@412d1bec7163 centos]# time cp -al updates updates2

real  0m0.043s
user  0m0.000s
sys  0m0.043s
```